### PR TITLE
Display the specific FS error using LED blink codes

### DIFF
--- a/src/memcard_simulator.c
+++ b/src/memcard_simulator.c
@@ -279,20 +279,26 @@ void process_memcard_req(MemoryCard* mc) {
 
 void blink_led() {
 	board_led_on();
-	sleep_ms(250);
+	sleep_ms(50);
 	board_led_off();
-	sleep_ms(250);
+	sleep_ms(200);
 }
 
 int simulate_memory_card() {
 	MemoryCard mc;
 
-	if(0 == memory_card_init(&mc)) {
+	int status = memory_card_init(&mc);
+
+	if(status == 0) {
 		board_led_on();
 	} else {
 		/* Blink LED forever */
 		while (true) {
-			blink_led();
+			for(int i = 0; i < status; i++) {
+				blink_led();
+			}
+
+			sleep_ms(1000);
 		}
 	}
 

--- a/src/memory_card.c
+++ b/src/memory_card.c
@@ -12,11 +12,11 @@ uint32_t memory_card_init(MemoryCard* mc) {
 	if(LFS_ERR_OK == lfs_mount(&lfs, &LFS_CFG)) {
 		if(LFS_ERR_OK == lfs_file_open(&lfs, &memcard, MEMCARD_FILE_NAME, LFS_O_RDONLY)) {
 			if(MC_SIZE != lfs_file_read(&lfs, &memcard, mc->data, MC_SIZE)) {
-				status = 1;	// failed to read memory card image
+				status = 3;	// failed to read memory card image
 			}
 			lfs_file_close(&lfs, &memcard);
 		} else  {
-			status = 1;	// failed to open memcard file
+			status = 2;	// failed to open memcard file
 		}
 		lfs_unmount(&lfs);
 	} else {


### PR DESCRIPTION
My Pico just kept blinking no matter what (tried flashing different firmware versions, erasing the "built-in" memory card file & replacing it with an empty one several times) and I wanted to know why it was failing, so I implemented simple blink error codes:

1 flash = FS mount error
2 flashes = File open error
3 flashes = File read error

Turns out my Pico is failing with 3 flashes, so it cannot read the file properly, meaning the file on the internal FS is smaller than expected. Not sure why that is happening, as the file I uploaded is exactly 131072 bytes (I used the empty memory card example which is provided in this repo).

I figured it might be useful to others for diagnosing such issues.