### PR TITLE
Display the specific FS error using LED blink codes (with the correct branch)

### DIFF
--- a/src/memcard_simulator.c
+++ b/src/memcard_simulator.c
@@ -277,22 +277,28 @@ void process_memcard_req(MemoryCard* mc) {
 	return;
 }
 
-void blink_led() {
-	board_led_on();
-	sleep_ms(250);
-	board_led_off();
-	sleep_ms(250);
+void blink_led(int err) {
+	for(int i = 0; i < err; i++) {
+		board_led_on();
+		sleep_ms(50);
+		board_led_off();
+		sleep_ms(200);
+	}
+
+	sleep_ms(1000);
 }
 
 int simulate_memory_card() {
 	MemoryCard mc;
 
-	if(0 == memory_card_init(&mc)) {
+	int status = memory_card_init(&mc);
+
+	if(status == 0) {
 		board_led_on();
 	} else {
 		/* Blink LED forever */
 		while (true) {
-			blink_led();
+			blink_led(status);
 		}
 	}
 

--- a/src/memory_card.c
+++ b/src/memory_card.c
@@ -11,12 +11,19 @@ uint32_t memory_card_init(MemoryCard* mc) {
 	mc->flag_byte = MC_FLAG_BYTE_DEF;
 	if(LFS_ERR_OK == lfs_mount(&lfs, &LFS_CFG)) {
 		if(LFS_ERR_OK == lfs_file_open(&lfs, &memcard, MEMCARD_FILE_NAME, LFS_O_RDONLY)) {
-			if(MC_SIZE != lfs_file_read(&lfs, &memcard, mc->data, MC_SIZE)) {
-				status = 1;	// failed to read memory card image
+			lfs_ssize_t size = lfs_file_read(&lfs, &memcard, mc->data, MC_SIZE);
+			
+			if(size < 0) {
+				status = 3; // failed to read memcard file
+			} else if(size == 0) {
+				status = 4; // memcard file is empty
+			} else if(size != MC_SIZE) {
+				status = 5; // memcard file size is incorrect
 			}
+
 			lfs_file_close(&lfs, &memcard);
 		} else  {
-			status = 1;	// failed to open memcard file
+			status = 2;	// failed to open memcard file
 		}
 		lfs_unmount(&lfs);
 	} else {


### PR DESCRIPTION
My Pico just kept blinking no matter what (tried flashing different firmware versions, erasing the "built-in" memory card file & replacing it with an empty one several times) and I wanted to know why it was failing, so I implemented simple blink error codes:

- 1 flash = FS mount error
- 2 flashes = Memory card file open error
- 3 flashes = Memory card file read error
- 4 flashes = Memory card file is empty
- 5 flashes = Memory card file contains data, but its size is incorrect 

Turns out my Pico is failing with 4 flashes, so it cannot read the file properly as it thinks it contains 0 bytes. Not sure why that is happening, as the file I uploaded is exactly 131072 bytes (I used the empty memory card example which is provided in this repo).

I figured it might be useful to others for diagnosing such issues.

---

This is a follow-up to my [previous pull request](https://github.com/dangiu/PicoMemcard/pull/11), where I unknowingly requested to push to the main branch instead of the development one. Also made a slight change to the commit by request, and added more error codes which may be useful.