### PR TITLE
QTPY RP2040 Support, adjustments to better support multiple boards

### DIFF
--- a/inc/config.h
+++ b/inc/config.h
@@ -10,8 +10,12 @@
 #define MC_RECONNECT_TIME	1000				// time (in ms) the memory card stays disconnected when simulating reconnection
 
 /* Board targeted by build */
+//#define PICO
+//#define WAVESHARE_RP2040_ZERO
+//#define ADAFRUIT_QTPY_RP2040
+#ifndef PICO_BOARD
 #define PICO
-//#define RP2040ZERO
+#endif
 
 /* PSX Interface Pinout */
 #ifdef PICO
@@ -22,13 +26,23 @@
 	#define PIN_ACK 9
 #endif
 
-#ifdef RP2040ZERO
+#ifdef WAVESHARE_RP2040_ZERO
 	#define PIN_DAT 9
 	#define PIN_CMD PIN_DAT + 1		// must be immediately after PIN_DAT
 	#define PIN_SEL PIN_CMD + 1		// must be immediately after PIN_CMD
 	#define PIN_CLK PIN_SEL + 1		// must be immediately after PIN_SEL
 	#define PIN_ACK 13
 #endif
+
+#ifdef ADAFRUIT_QTPY_RP2040
+	#define PIN_DAT 26
+	#define PIN_CMD PIN_DAT + 1		// must be immediately after PIN_DAT
+	#define PIN_SEL PIN_CMD + 1		// must be immediately after PIN_CMD
+	#define PIN_CLK PIN_SEL + 1		// must be immediately after PIN_SEL
+	#define PIN_ACK 24
+#endif
+
+
 
 /* SD Card Configuration */
 #define BLOCK_SIZE	512				// SD card communicate using only 512 block size for consistency
@@ -40,11 +54,18 @@
 	#define PIN_SS		17
 #endif
 
-#ifdef RP2040ZERO
+#ifdef WAVESHARE_RP2040_ZERO
 	#define PIN_MISO	0
 	#define PIN_MOSI	3
 	#define PIN_SCK		2
 	#define PIN_SS		1
+#endif
+
+#ifdef ADAFRUIT_QTPY_RP2040
+	#define PIN_MISO	3
+	#define PIN_MOSI	4
+	#define PIN_SCK		6
+	#define PIN_SS		5
 #endif
 
 #endif

--- a/src/led.c
+++ b/src/led.c
@@ -2,18 +2,18 @@
 #include "config.h"
 #include "hardware/gpio.h"
 #include "hardware/pio.h"
-#ifdef RP2040ZERO
+#if defined(WAVESHARE_RP2040_ZERO) || defined(ADAFRUIT_QTPY_RP2040)
 #include "ws2812.pio.h"
 #endif
 
-#ifdef PICO
-#define PICO_LED_PIN 25
-#endif
+//#ifdef PICO
+//#define PICO_LED_PIN 25
+//#endif
 
 static uint smWs2813;
 static uint offsetWs2813;
 
-#ifdef RP2040ZERO
+#if defined(WAVESHARE_RP2040_ZERO) || defined(ADAFRUIT_QTPY_RP2040)
 void ws2812_put_pixel(uint32_t pixel_grb) {
 	pio_sm_put_blocking(pio1, smWs2813, pixel_grb << 8u);
 }
@@ -24,18 +24,19 @@ void ws2812_put_rgb(uint8_t red, uint8_t green, uint8_t blue) {
 #endif
 
 void led_init() {
-	#ifdef RP2040ZERO
+	#if defined(WAVESHARE_RP2040_ZERO) || defined(ADAFRUIT_QTPY_RP2040)
+	// gpio_put(11, true); // This might not need to be here, should be removed for non QTPY2040 use
 	offsetWs2813 = pio_add_program(pio1, &ws2812_program);
 	smWs2813 = pio_claim_unused_sm(pio1, true);
-	ws2812_program_init(pio1, smWs2813, offsetWs2813, 16, 800000, true);
+	ws2812_program_init(pio1, smWs2813, offsetWs2813, PICO_DEFAULT_WS2812_PIN, 800000, true);
 	#endif
 }
 
 void led_output_sync_status(bool out_of_sync) {
 	#ifdef PICO
-	gpio_put(PICO_LED_PIN, !out_of_sync);
+	gpio_put(PICO_DEFAULT_LED_PIN, !out_of_sync);
 	#endif
-	#ifdef RP2040ZERO
+	#if defined(WAVESHARE_RP2040_ZERO) || defined(ADAFRUIT_QTPY_RP2040)
 	if(out_of_sync)
 		ws2812_put_rgb(255, 255, 0);
 	else
@@ -46,25 +47,25 @@ void led_output_sync_status(bool out_of_sync) {
 void led_blink_error(int amount) {
 	/* ensure led is off */
 	#ifdef PICO
-	gpio_put(PICO_LED_PIN, false);
+	gpio_put(PICO_DEFAULT_LED_PIN, false);
 	#endif
-	#ifdef RP2040ZERO
+	#if defined(WAVESHARE_RP2040_ZERO) || defined(ADAFRUIT_QTPY_RP2040)
 	ws2812_put_rgb(0, 0, 0);
 	#endif
 	sleep_ms(500);
 	/* start blinking */
 	for(int i = 0; i < amount; ++i) {
 		#ifdef PICO
-		gpio_put(PICO_LED_PIN, true);
+		gpio_put(PICO_DEFAULT_LED_PIN, true);
 		#endif
-		#ifdef RP2040ZERO
+		#if defined(WAVESHARE_RP2040_ZERO) || defined(ADAFRUIT_QTPY_RP2040)
 		ws2812_put_rgb(255, 0, 0);
 		#endif
 		sleep_ms(500);
 		#ifdef PICO
-		gpio_put(PICO_LED_PIN, false);
+		gpio_put(PICO_DEFAULT_LED_PIN, false);
 		#endif
-		#ifdef RP2040ZERO
+		#if defined(WAVESHARE_RP2040_ZERO) || defined(ADAFRUIT_QTPY_RP2040)
 		ws2812_put_rgb(0, 0, 0);
 		#endif
 		sleep_ms(500);
@@ -73,14 +74,14 @@ void led_blink_error(int amount) {
 
 void led_output_mc_change() {
 	#ifdef PICO
-	gpio_put(PICO_LED_PIN, false);
+	gpio_put(PICO_DEFAULT_LED_PIN, false);
 	sleep_ms(100);
-	gpio_put(PICO_LED_PIN, true);
+	gpio_put(PICO_DEFAULT_LED_PIN, true);
 	sleep_ms(100);
-	gpio_put(PICO_LED_PIN, false);
+	gpio_put(PICO_DEFAULT_LED_PIN, false);
 	sleep_ms(100);
 	#endif
-	#ifdef RP2040ZERO
+	#if defined(WAVESHARE_RP2040_ZERO) || defined(ADAFRUIT_QTPY_RP2040)
 	ws2812_put_rgb(0, 0, 255);
 	sleep_ms(100);
 	ws2812_put_rgb(0, 0, 0);


### PR DESCRIPTION
This is my first pull request _and_ my first time doing anything in C. Please feel free to point out any mistakes, and sorry for hacking away at your code.

The Adafruit QTPY RP2040 is tested and working with these changes, with the exception of the LED. I can't for the life of me figure out why it's not working. I want to make sure that the current code is still working on the RP2040 Zero, and I have one due in later this week. 

Also made other changes so that the target board can be set with `-DPICO_BOARD=`. This is the same flag used by pico-sdk to set default pins and other tidbits per board. [More info about that and the various board names here.](https://github.com/raspberrypi/pico-sdk/tree/master/src/boards/include/boards)

TODOs include fixing the LED, confirming nothing is broke on Pico or Waveshare_RP2040_Zero, and making a nice svg pinout picture. I don't know how to do that, but I do have a crude text layout.

```
PS CARD                            SD CARD
Inputs on left                Pins on right

And DET, optional.          And power input
                 ________________
                / QT          PY \
            CLK o GP29       5V  o
            SEL o GP28       GND o GND
            CMD o GP27       3.3 o 3.3V
            DAT o GP26       GP3 o MOSI / SI
            ACK o GP24       GP4 o MISO / SO
                o GP25       GP6 o SCK / CLK 
            DET o_GP20_______GP5_o SS / CS 


             LED   GP12
           LED PWR GP11
```

I also couldn't find where the DET pin was used in the code. In the future I'd like to add the option to use buttons on the GPIO to change MC images since the PS2 doesn't currently support the controller button combo, to my knowledge. The qtpy 2040 is a bit short on pins so having an extra one free would be nice. 

Thanks!