### PR TITLE
PicoMemCard+ reloads the last card you had loaded after a restart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Memory card images must be exactly 128KB (131072 bytes) in size. PicoMemcard and
 For other file formats, try using [MemcardRex] for converting to the desired output.
 
 * **PicoMemcard** only supports a single image which must be named exactly `MEMCARD.MCR`.
-* **PicoMemcard+** supports hundreds of images. Each image must be named `N.MCR` where `N` is an integer number (e.g. `0.MCR`, `1.MCR`...). On boot the first image loaded will always be the one with the lowest number.
+* **PicoMemcard+** supports hundreds of images. Each image must be named `N.MCR` where `N` is an integer number (e.g. `0.MCR`, `1.MCR`...). On boot your previously loaded image will be reloaded, unless it's a fresh card then `0.MCR` will be loaded.
 
 Inside `docs/images` you can find two memory card images. One has a couple of saves on it so you can test if everything works correctly, the other is completely empty.
 
@@ -127,11 +127,11 @@ Additionally this method does not work on PS2 Memory Cards and Controllers are w
 ## Syncing Changes
 Generally speaking, new data written to PicoMemcard (e.g. when you save) is permanently stored only after a short period of time (due to hardware limitation). The on board LED indicates whether all changes have been stored or not, in particular:
 * On Rapsbery Pi Pico the LED will be on when all changes have been saved, off otherwise.
-* On RP2040-Zero the LED will be green when all changes have been saved, yellow otherwise
+* On RP2040-Zero the LED will be solid green when all changes have been saved, red otherwise.
 
 Unlike **PicoMemcard+** that tries to write new changes as soon as possible, **PicoMemcard** will generally do it only after a period of inactivity (around 5 seconds). If you want to force **PicoMemcard** to immediately sync you can press `START + SELECT + TRIANGLE`.
 
-**Attention**: after you save your game, make sure to wait for the LED to be green before turning off the console otherwise you might lose your more recent progress!
+**Attention**: after you save your game, make sure to wait for the LED to be solid green before turning off the console otherwise you might lose your more recent progress!
 
 ## 3D-Printed Case
 I've finally designed a 3D-printable case for the different PicoMemcard PCBs. It helps inserting correctly the PCB and ensuring that the the connection to the PSX is optimal. The same result, albeit more janky, can be achieved using a folded sheet of paper as a spacer.
@@ -158,15 +158,15 @@ In particular, the RP2040-Zero has RGB LED that provides a more clear output. Th
 | Status | Pico | RP2040-Zero
 | --- | --- | --- |
 | Failed to read memory card image | Slow blinking led  | Red blinking led
-| Data not fully synced (do not turn off PSX)| Led off | Yellow led |
-| Data synced | Led on | Green led |
+| Data not fully synced (do not turn off PSX)| Led off | Red led (or flashing red and green) |
+| Data synced | Led on | Green solid led |
 
 ### PicoMemcard+ Status
 | Status | Pico | RP2040-Zero
 | --- | --- | --- |
 | Failed to read SD card | Blinking led  | Red blinking led
-| Data not fully synced (do not turn off PSX)| Led off | Yellow led |
-| Data synced | Led on | Green led |
+| Data not fully synced (do not turn off PSX)| Led off | Red led (or flashing red and green) |
+| Data synced | Led on | Green solid led |
 | Memory Card image changed | Three fast blinks | Single blue blink |
 | Memory Card image not changed (end of list) | Nine fast blinks | Single orange blink |
 | New Memory Card image created | Multiple very fast blinks | Single light blue blink |

--- a/inc/config.h
+++ b/inc/config.h
@@ -13,6 +13,9 @@
 #define PICO
 //#define RP2040ZERO
 
+/* Invert red and green. Uncomment this if the LED colours for your RP2040 Zero are incorrect. */
+#define INVERT_RED_GREEN
+
 /* PSX Interface Pinout */
 #ifdef PICO
 	#define PIN_DAT 5

--- a/inc/memcard_manager.h
+++ b/inc/memcard_manager.h
@@ -17,7 +17,8 @@
 bool memcard_manager_exist(uint8_t* filename);
 uint32_t memcard_manager_count();
 uint32_t memcard_manager_get(uint32_t index, uint8_t* out_filename);
-#define memcard_manager_get_first(out_filename) memcard_manager_get(0, (out_filename))
+#define memcard_manager_get_initial(out_filename) memcard_manager_get(memcard_manager_get_prev_loaded_memcard_index(), (out_filename))
+uint32_t memcard_manager_get_prev_loaded_memcard_index();
 uint32_t memcard_manager_get_next(uint8_t* filename, uint8_t* out_nextfile);
 uint32_t memcard_manager_get_prev(uint8_t* filename, uint8_t* out_prevfile);
 uint32_t memcard_manager_create(uint8_t* out_filename);

--- a/src/led.c
+++ b/src/led.c
@@ -19,7 +19,11 @@ void ws2812_put_pixel(uint32_t pixel_grb) {
 	pio_sm_put(pio1, smWs2813, pixel_grb << 8u);
 }
 void ws2812_put_rgb(uint8_t red, uint8_t green, uint8_t blue) {
+	#ifdef INVERT_RED_GREEN
+	uint32_t mask = (red << 16) | (green << 8) | (blue << 0);
+	#elif
 	uint32_t mask = (green << 16) | (red << 8) | (blue << 0);
+	#endif
 	ws2812_put_pixel(mask);
 }
 #endif
@@ -37,10 +41,12 @@ void led_output_sync_status(bool out_of_sync) {
 	gpio_put(PICO_LED_PIN, !out_of_sync);
 	#endif
 	#ifdef RP2040ZERO
-	if(out_of_sync)
-		ws2812_put_rgb(255, 200, 0);
-	else
+	if(out_of_sync) {
+		ws2812_put_rgb(255, 0, 0);
+		sleep_ms(25);
+	} else {
 		ws2812_put_rgb(0, 255, 0);
+	}
 	#endif
 }
 

--- a/src/memcard_simulator.c
+++ b/src/memcard_simulator.c
@@ -370,11 +370,14 @@ _Noreturn int simulate_memory_card() {
 			sleep_ms(2000);
 		}
 	}
-	status = memcard_manager_get_first(mc_file_name);	// get first memory card
+	status = memcard_manager_get_initial(mc_file_name);	// get initial memory card to load
 	if(status != MM_OK) {
-		while(true) {
-			led_blink_error(status);
-			sleep_ms(1000);
+		status = memcard_manager_get(0, mc_file_name);	// revert to first mem card if failing to load previously loaded card
+		if(status != MM_OK) {
+			while(true) {
+				led_blink_error(status);
+				sleep_ms(1000);
+			}
 		}
 	}
 	status = memory_card_import(&mc, mc_file_name);


### PR DESCRIPTION
Hey, thanks for the great software! It inspired me to get creative and contribute, and I think this is a nice improvement! Hopefully the community thinks so too.
This is also my first public pull request on GitHub, so that's pretty exciting for me.

Here's the changes:
- PicoMemCard+ now reloads the last card you had loaded after a restart.
- Handles creating new cards, index being out of range and the dat file not existing.
- Changed out of sync state LED to red, as orange looks very similar to green on RP2040 Zero. 
- Added small delay to out of sync state LED as previously it would flash green and red/orange quickly and would be hard to see if it is still syncing. Note: This doesn't add any noticeable delay to saving. 
- Added flag to invert red and green for newer RP2040 Zero boards.

Sidenote: The return value for update_prev_loaded_memcard_index isn't used but included for debugging purposes. I think it's better to retain the rest of the functionality in the event of an error, rather than stop the execution flow there. In theory this will never happen without other operations erroring anyway though.

Please let me know what you think, or if there's anything that you think should be improved. I tried to keep the style inline with the rest of the project.

Cheers :)