### PR TITLE
Changes to bring PMC inline with PMC+

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ Additionally this method does not work on PS2 Memory Cards and Controllers are w
 ## Syncing Changes
 Generally speaking, new data written to PicoMemcard (e.g. when you save) is permanently stored only after a short period of time (due to hardware limitation). The on board LED indicates whether all changes have been stored or not, in particular:
 * On Rapsbery Pi Pico the LED will be on when all changes have been saved, off otherwise.
-* On RP2040-Zero the LED will be green when all changes have been saved, yellow otherwise
+* On RP2040-Zero the LED will be solid green when all changes have been saved, red otherwise.
 
 Unlike **PicoMemcard+** that tries to write new changes as soon as possible, **PicoMemcard** will generally do it only after a period of inactivity (around 5 seconds). If you want to force **PicoMemcard** to immediately sync you can press `START + SELECT + TRIANGLE`.
 
-**Attention**: after you save your game, make sure to wait for the LED to be green before turning off the console otherwise you might lose your more recent progress!
+**Attention**: after you save your game, make sure to wait for the LED to be solid green before turning off the console otherwise you might lose your more recent progress!
 
 ## General Warnings
 I would recommend to never plug PicoMemcard both into the PC (via USB) and the PSX at the same time! Otherwise the 5V provided by USB would end up on the 3.3V rail of the PSX. I'm not really sure if this could cause actual damage but I would avoid risking it.

--- a/inc/config.h
+++ b/inc/config.h
@@ -11,6 +11,8 @@
 #define PICO
 //#define RP2040ZERO
 
+/* Invert red and green. Uncomment this if the LED colours for your RP2040 Zero are incorrect. */
+#define INVERT_RED_GREEN
 
 /* PSX Interface Pinout */
 #ifdef PICO

--- a/src/led.c
+++ b/src/led.c
@@ -18,7 +18,11 @@ void ws2812_put_pixel(uint32_t pixel_grb) {
 	pio_sm_put_blocking(pio1, smWs2813, pixel_grb << 8u);
 }
 void ws2812_put_rgb(uint8_t red, uint8_t green, uint8_t blue) {
+	#ifdef INVERT_RED_GREEN
+	uint32_t mask = (red << 16) | (green << 8) | (blue << 0);
+	#elif
 	uint32_t mask = (green << 16) | (red << 8) | (blue << 0);
+	#endif
 	ws2812_put_pixel(mask);
 }
 #endif
@@ -36,10 +40,12 @@ void led_output_sync_status(bool out_of_sync) {
 	gpio_put(PICO_LED_PIN, !out_of_sync);
 	#endif
 	#ifdef RP2040ZERO
-	if(out_of_sync)
-		ws2812_put_rgb(255, 255, 0);
-	else
+	if(out_of_sync) {
+		ws2812_put_rgb(255, 0, 0);
+		sleep_ms(25);
+	} else {
 		ws2812_put_rgb(0, 255, 0);
+	}
 	#endif
 }
 


### PR DESCRIPTION
This PR relies on PR #41
It brings PMC inline with PMC+. Here are the changes:

- Changed out of sync state LED to red, for better visibility
- Added small delay to out of sync state LED as previously it would flash green and red/orange quickly and would be hard to see if it is still syncing.N ote: This doesn't add any noticeable delay to saving.
- Added flag to invert red and green for newer RP2040 Zero boards.