### PR TITLE
Submodule using https:// url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "no-OS-FatFS-SD-SPI-RPi-Pico"]
 	path = no-OS-FatFS-SD-SPI-RPi-Pico
-	url = git@github.com:carlk3/no-OS-FatFS-SD-SPI-RPi-Pico.git
+	url = https://github.com/carlk3/no-OS-FatFS-SD-SPI-RPi-Pico.git


### PR DESCRIPTION
When I tried to pull the submodules using the following command it failed
```bash
$ git submodule update --init
```

```
Submodule 'no-OS-FatFS-SD-SPI-RPi-Pico' (git@github.com:carlk3/no-OS-FatFS-SD-SPI-RPi-Pico.git) registered for path 'no-OS-FatFS-SD-SPI-RPi-Pico'
Cloning into 'C:/Users/jd/Documents/Projects/PicoMemcardW/no-OS-FatFS-SD-SPI-RPi-Pico'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:carlk3/no-OS-FatFS-SD-SPI-RPi-Pico.git' into submodule path 'C:/Users/jd/Documents/Projects/PicoMemcardW/no-OS-FatFS-SD-SPI-RPi-Pico' failed
Failed to clone 'no-OS-FatFS-SD-SPI-RPi-Pico'.
```
The original git URI requires authentication to github (even for readonly access), where the https does not.
After making the change in the PR, I was able to successfully pull the submodules.