### PR TITLE
Pico W LED support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
+set(PICO_BOARD pico_w)
+
 include(pico_sdk_import.cmake)
 
 project(picomemcard_project C CXX ASM)
@@ -35,6 +37,18 @@ target_include_directories(PicoMemcard PUBLIC
 
 pico_enable_stdio_uart(PicoMemcard 1)	# enable only UART stdio
 
-target_link_libraries(PicoMemcard pico_stdlib pico_multicore pico_time hardware_pio tinyusb_device tinyusb_board FatFs_SPI)
+target_link_libraries(
+  PicoMemcard
+  pico_stdlib
+  pico_multicore
+  pico_time
+  hardware_pio
+  tinyusb_device
+  tinyusb_board
+  FatFs_SPI
+
+  pico_cyw43_arch_none # If you do not need the TCP/IP stack but wish to use the on-board LED on a Pico W
+  hardware_adc
+)
 
 pico_add_extra_outputs(PicoMemcard)

--- a/inc/led.h
+++ b/inc/led.h
@@ -10,4 +10,8 @@ void led_output_mc_change();
 void led_output_end_mc_list();
 void led_output_new_mc();
 
+int32_t is_pico_w();
+void init_led(uint32_t pin);
+void set_led(uint32_t pin, uint32_t level);
+
 #endif

--- a/src/led.c
+++ b/src/led.c
@@ -12,7 +12,6 @@
 
 #ifdef PICO
 #define PICO_LED_PIN 25
-#define CYW43_WL_GPIO_LED_PIN 0
 #endif
 
 static uint smWs2813;

--- a/src/led.c
+++ b/src/led.c
@@ -163,9 +163,9 @@ int32_t is_pico_w() {
     else {
       gpio_init(VSYS_CTL_GPIO);              // GPIO
       gpio_set_dir(VSYS_CTL_GPIO, GPIO_OUT); // output
-      set_led(VSYS_CTL_GPIO, 0);            // low
+      gpio_put(VSYS_CTL_GPIO, 0);            // low
       if (adc_read() < ONE_VOLT) {
-          set_led(VSYS_CTL_GPIO, 1);        // high
+          gpio_put(VSYS_CTL_GPIO, 1);        // high
           picoW = 1;                         // Pico W
       } else {
           picoW = 0;                         // Pico

--- a/src/led.c
+++ b/src/led.c
@@ -2,12 +2,22 @@
 #include "config.h"
 #include "hardware/gpio.h"
 #include "hardware/pio.h"
+#include "hardware/adc.h"
+#ifdef PICO
+#include "pico/cyw43_arch.h"
+#endif
 #ifdef RP2040ZERO
 #include "ws2812.pio.h"
 #endif
 
+#ifdef PICO
+#define PICO_LED_PIN 25
+#define CYW43_WL_GPIO_LED_PIN 0
+#endif
+
 static uint smWs2813;
 static uint offsetWs2813;
+static int32_t picoW = -1;
 
 #ifdef RP2040ZERO
 void ws2812_put_pixel(uint32_t pixel_grb) {
@@ -25,6 +35,14 @@ void ws2812_put_rgb(uint8_t red, uint8_t green, uint8_t blue) {
 #endif
 
 void led_init() {
+  #ifdef PICO
+  if (is_pico_w()) {
+    if (cyw43_arch_init()) {
+      picoW = 0;
+    }
+  }
+  init_led(PICO_LED_PIN);
+  #endif
 	#ifdef RP2040ZERO
 	offsetWs2813 = pio_add_program(pio1, &ws2812_program);
 	smWs2813 = pio_claim_unused_sm(pio1, true);
@@ -34,7 +52,7 @@ void led_init() {
 
 void led_output_sync_status(bool out_of_sync) {
 	#ifdef PICO
-	gpio_put(PICO_DEFAULT_LED_PIN, !out_of_sync);
+	set_led(PICO_LED_PIN, !out_of_sync);
 	#endif
 	#ifdef RP2040ZERO
 	if(out_of_sync) {
@@ -49,7 +67,7 @@ void led_output_sync_status(bool out_of_sync) {
 void led_blink_error(int amount) {
 	/* ensure led is off */
 	#ifdef PICO
-	gpio_put(PICO_DEFAULT_LED_PIN, false);
+	set_led(PICO_LED_PIN, false);
 	#endif
 	#ifdef RP2040ZERO
 	ws2812_put_rgb(0, 0, 0);
@@ -58,14 +76,14 @@ void led_blink_error(int amount) {
 	/* start blinking */
 	for(int i = 0; i < amount; ++i) {
 		#ifdef PICO
-		gpio_put(PICO_DEFAULT_LED_PIN, true);
+		set_led(PICO_LED_PIN, true);
 		#endif
 		#ifdef RP2040ZERO
 		ws2812_put_rgb(255, 0, 0);
 		#endif
 		sleep_ms(500);
 		#ifdef PICO
-		gpio_put(PICO_DEFAULT_LED_PIN, false);
+		set_led(PICO_LED_PIN, false);
 		#endif
 		#ifdef RP2040ZERO
 		ws2812_put_rgb(0, 0, 0);
@@ -76,11 +94,11 @@ void led_blink_error(int amount) {
 
 void led_output_mc_change() {
 	#ifdef PICO
-	gpio_put(PICO_DEFAULT_LED_PIN, false);
+	set_led(PICO_LED_PIN, false);
 	sleep_ms(100);
-	gpio_put(PICO_DEFAULT_LED_PIN, true);
+	set_led(PICO_LED_PIN, true);
 	sleep_ms(100);
-	gpio_put(PICO_DEFAULT_LED_PIN, false);
+	set_led(PICO_LED_PIN, false);
 	sleep_ms(100);
 	#endif
 	#ifdef RP2040ZERO
@@ -93,11 +111,11 @@ void led_output_mc_change() {
 void led_output_end_mc_list() {
 	#ifdef PICO
 	for(int i = 0; i < 3; ++i) {
-		gpio_put(PICO_DEFAULT_LED_PIN, false);
+		set_led(PICO_LED_PIN, false);
 		sleep_ms(100);
-		gpio_put(PICO_DEFAULT_LED_PIN, true);
+		set_led(PICO_LED_PIN, true);
 		sleep_ms(100);
-		gpio_put(PICO_DEFAULT_LED_PIN, false);
+		set_led(PICO_LED_PIN, false);
 		sleep_ms(100);
 	}
 	#endif
@@ -111,17 +129,64 @@ void led_output_end_mc_list() {
 void led_output_new_mc() {
 	#ifdef PICO
 	for(int i = 0; i < 10; ++i) {
-		gpio_put(PICO_DEFAULT_LED_PIN, false);
+		set_led(PICO_LED_PIN, false);
 		sleep_ms(50);
-		gpio_put(PICO_DEFAULT_LED_PIN, true);
+		set_led(PICO_LED_PIN, true);
 		sleep_ms(50);
-		gpio_put(PICO_DEFAULT_LED_PIN, false);
+		set_led(PICO_LED_PIN, false);
 		sleep_ms(50);
 	}
 	#endif
 	#ifdef RP2040ZERO
 	ws2812_put_rgb(52, 171, 235);	// light blue
 	sleep_ms(1000);
-	ws2812_put_rgb(0, 0, 0);
+	led_disable();
 	#endif
+}
+
+// Attempt to check if device is a Raspberry Pi Pico W
+// Based on https://forums.raspberrypi.com/viewtopic.php?t=336884
+int32_t is_pico_w() {
+  if (picoW == -1) {
+    // When the VSYS_ADC is read on a Pico it will always be > 1V
+    // On a Pico-W it will be < 1V when GPIO25 is low
+    #define VSYS_ADC_GPIO  29
+    #define VSYS_ADC_CHAN   3
+    #define ONE_VOLT      409 // 1V divide by 3, as 12-bit with 3V3 Vref
+    #define VSYS_CTL_GPIO  25 // Enables VSYS_ADC on Pico-W
+    adc_init();
+    adc_gpio_init(VSYS_ADC_GPIO);
+    adc_select_input(VSYS_ADC_CHAN);
+    // Check to see if we can detect a Pico-W without using any GPIO
+    if (adc_read() < ONE_VOLT) {
+      picoW = 1;                             // Pico W
+    }
+    else {
+      gpio_init(VSYS_CTL_GPIO);              // GPIO
+      gpio_set_dir(VSYS_CTL_GPIO, GPIO_OUT); // output
+      set_led(VSYS_CTL_GPIO, 0);            // low
+      if (adc_read() < ONE_VOLT) {
+          set_led(VSYS_CTL_GPIO, 1);        // high
+          picoW = 1;                         // Pico W
+      } else {
+          picoW = 0;                         // Pico
+      }
+    }
+  }
+  return picoW;
+}
+
+void init_led(uint32_t pin) {
+  if (!is_pico_w() || (pin != 25)) {
+    gpio_init(pin);
+    gpio_set_dir(pin, GPIO_OUT);
+  }
+}
+
+void set_led(uint32_t pin, uint32_t level) {
+  if ((pin == 25) && is_pico_w()) {
+    cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, level);
+  } else {
+    gpio_put(pin, level);
+  }
 }

--- a/src/led.c
+++ b/src/led.c
@@ -6,10 +6,6 @@
 #include "ws2812.pio.h"
 #endif
 
-#ifdef PICO
-#define PICO_LED_PIN 25
-#endif
-
 static uint smWs2813;
 static uint offsetWs2813;
 
@@ -38,7 +34,7 @@ void led_init() {
 
 void led_output_sync_status(bool out_of_sync) {
 	#ifdef PICO
-	gpio_put(PICO_LED_PIN, !out_of_sync);
+	gpio_put(PICO_DEFAULT_LED_PIN, !out_of_sync);
 	#endif
 	#ifdef RP2040ZERO
 	if(out_of_sync) {
@@ -53,7 +49,7 @@ void led_output_sync_status(bool out_of_sync) {
 void led_blink_error(int amount) {
 	/* ensure led is off */
 	#ifdef PICO
-	gpio_put(PICO_LED_PIN, false);
+	gpio_put(PICO_DEFAULT_LED_PIN, false);
 	#endif
 	#ifdef RP2040ZERO
 	ws2812_put_rgb(0, 0, 0);
@@ -62,14 +58,14 @@ void led_blink_error(int amount) {
 	/* start blinking */
 	for(int i = 0; i < amount; ++i) {
 		#ifdef PICO
-		gpio_put(PICO_LED_PIN, true);
+		gpio_put(PICO_DEFAULT_LED_PIN, true);
 		#endif
 		#ifdef RP2040ZERO
 		ws2812_put_rgb(255, 0, 0);
 		#endif
 		sleep_ms(500);
 		#ifdef PICO
-		gpio_put(PICO_LED_PIN, false);
+		gpio_put(PICO_DEFAULT_LED_PIN, false);
 		#endif
 		#ifdef RP2040ZERO
 		ws2812_put_rgb(0, 0, 0);
@@ -80,11 +76,11 @@ void led_blink_error(int amount) {
 
 void led_output_mc_change() {
 	#ifdef PICO
-	gpio_put(PICO_LED_PIN, false);
+	gpio_put(PICO_DEFAULT_LED_PIN, false);
 	sleep_ms(100);
-	gpio_put(PICO_LED_PIN, true);
+	gpio_put(PICO_DEFAULT_LED_PIN, true);
 	sleep_ms(100);
-	gpio_put(PICO_LED_PIN, false);
+	gpio_put(PICO_DEFAULT_LED_PIN, false);
 	sleep_ms(100);
 	#endif
 	#ifdef RP2040ZERO
@@ -97,11 +93,11 @@ void led_output_mc_change() {
 void led_output_end_mc_list() {
 	#ifdef PICO
 	for(int i = 0; i < 3; ++i) {
-		gpio_put(PICO_LED_PIN, false);
+		gpio_put(PICO_DEFAULT_LED_PIN, false);
 		sleep_ms(100);
-		gpio_put(PICO_LED_PIN, true);
+		gpio_put(PICO_DEFAULT_LED_PIN, true);
 		sleep_ms(100);
-		gpio_put(PICO_LED_PIN, false);
+		gpio_put(PICO_DEFAULT_LED_PIN, false);
 		sleep_ms(100);
 	}
 	#endif
@@ -115,11 +111,11 @@ void led_output_end_mc_list() {
 void led_output_new_mc() {
 	#ifdef PICO
 	for(int i = 0; i < 10; ++i) {
-		gpio_put(PICO_LED_PIN, false);
+		gpio_put(PICO_DEFAULT_LED_PIN, false);
 		sleep_ms(50);
-		gpio_put(PICO_LED_PIN, true);
+		gpio_put(PICO_DEFAULT_LED_PIN, true);
 		sleep_ms(50);
-		gpio_put(PICO_LED_PIN, false);
+		gpio_put(PICO_DEFAULT_LED_PIN, false);
 		sleep_ms(50);
 	}
 	#endif


### PR DESCRIPTION
Previous PR is deleted due to restructure on my fork.

```
Added support for Pico W, specifically LED support, as the LED is no longer wired to PICO_DEFAULT_LED_PIN (GPIO 25), but is now wired to CYW43_WL_GPIO_LED_PIN (GPIO 0 on the Wireless Module)

This change does not require a separate binary for PICO and PICO_W, but will increase the size of said binary.

Edits based on https://forums.raspberrypi.com/viewtopic.php?t=336884
```
Unlike last time, this one has been tested and works perfectly on both W and non-W variants.
Fixes #52 - Replaces #45