### PR TITLE
Add support for the RGB LED on the board sold on Aliexpress

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ In particular, the RP2040-Zero has RGB LED that provides a more clear output. Th
 | Data synced | Led on | Green led |
 
 ### PicoMemcard+ Status
-| Status | Pico | RP2040-Zero
-| --- | --- | --- |
-| Failed to read SD card | Blinking led  | Red blinking led
-| Data not fully synced (do not turn off PSX)| Led off | Yellow led |
-| Data synced | Led on | Green led |
-| Memory Card image changed | Three fast blinks | Single blue blink |
-| Memory Card image not changed (end of list) | Nine fast blinks | Single orange blink |
-| New Memory Card image created | Multiple very fast blinks | Single light blue blink |
+| Status | Pico | RP2040-Zero | Pico RGB
+| --- | --- | --- | --- |
+| Failed to read SD card | Blinking led  | Red blinking led | Red blinking led |
+| Data not fully synced (do not turn off PSX)| Led off | Yellow led | Yellow led |
+| Data synced | Led on | Green led | Green led |
+| Memory Card image changed | Three fast blinks | Single blue blink | Single blue blink |
+| Memory Card image not changed (end of list) | Nine fast blinks | Single orange blink | Single purple blink |
+| New Memory Card image created | Multiple very fast blinks | Single light blue blink | Single light blue blink |
 
 ## General Warnings
 I would recommend to never plug PicoMemcard both into the PC (via USB) and the PSX at the same time! Otherwise the 5V provided by USB would end up on the 3.3V rail of the PSX. I'm not really sure if this could cause actual damage but I would avoid risking it.

--- a/inc/config.h
+++ b/inc/config.h
@@ -12,6 +12,7 @@
 /* Board targeted by build */
 #define PICO
 //#define RP2040ZERO
+//#define PICO_RGB
 
 /* PSX Interface Pinout */
 #ifdef PICO
@@ -30,6 +31,14 @@
 	#define PIN_ACK 13
 #endif
 
+#ifdef PICO_RGB
+	#define PIN_DAT 5
+	#define PIN_CMD PIN_DAT + 1		// must be immediately after PIN_DAT
+	#define PIN_SEL PIN_CMD + 1		// must be immediately after PIN_CMD
+	#define PIN_CLK PIN_SEL + 1		// must be immediately after PIN_SEL
+	#define PIN_ACK 9
+#endif
+
 /* SD Card Configuration */
 #define BLOCK_SIZE	512				// SD card communicate using only 512 block size for consistency
 #define BAUD_RATE	5000 * 1000
@@ -45,6 +54,13 @@
 	#define PIN_MOSI	3
 	#define PIN_SCK		2
 	#define PIN_SS		1
+#endif
+
+#ifdef PICO_RGB
+	#define PIN_MISO	16
+	#define PIN_MOSI	19
+	#define PIN_SCK		18
+	#define PIN_SS		17
 #endif
 
 #endif

--- a/src/led.c
+++ b/src/led.c
@@ -10,6 +10,12 @@
 #define PICO_LED_PIN 25
 #endif
 
+#ifdef PICO_RGB
+#define PICO_RED_PIN 25
+#define PICO_GRN_PIN 24
+#define PICO_BLU_PIN 23
+#endif
+
 static uint smWs2813;
 static uint offsetWs2813;
 
@@ -30,6 +36,14 @@ void led_init() {
 	smWs2813 = pio_claim_unused_sm(pio1, true);
 	ws2812_program_init(pio1, smWs2813, offsetWs2813, 16, 800000, true);
 	#endif
+        #ifdef PICO_RGB
+        gpio_init(PICO_RED_PIN);
+        gpio_init(PICO_GRN_PIN);
+        gpio_init(PICO_BLU_PIN);
+        gpio_set_dir(PICO_RED_PIN, GPIO_OUT); 
+        gpio_set_dir(PICO_GRN_PIN, GPIO_OUT); 
+        gpio_set_dir(PICO_BLU_PIN, GPIO_OUT); 
+        #endif
 }
 
 void led_output_sync_status(bool out_of_sync) {
@@ -39,9 +53,23 @@ void led_output_sync_status(bool out_of_sync) {
 	#ifdef RP2040ZERO
 	if(out_of_sync)
 		ws2812_put_rgb(255, 200, 0);
-	else
+        else
 		ws2812_put_rgb(0, 255, 0);
 	#endif
+        #ifdef PICO_RGB
+        if(out_of_sync) {
+                //yellow
+                gpio_put(PICO_RED_PIN, 1);
+                gpio_put(PICO_GRN_PIN, 1);
+                gpio_put(PICO_BLU_PIN, 0);
+        }
+        else {
+                //green
+                gpio_put(PICO_RED_PIN, 0);
+                gpio_put(PICO_GRN_PIN, 1);
+                gpio_put(PICO_BLU_PIN, 0);
+        }
+        #endif
 }
 
 void led_blink_error(int amount) {
@@ -52,6 +80,11 @@ void led_blink_error(int amount) {
 	#ifdef RP2040ZERO
 	ws2812_put_rgb(0, 0, 0);
 	#endif
+        #ifdef PICO_RGB
+        gpio_put(PICO_RED_PIN, 0);
+        gpio_put(PICO_GRN_PIN, 0);
+        gpio_put(PICO_BLU_PIN, 0);
+        #endif
 	sleep_ms(500);
 	/* start blinking */
 	for(int i = 0; i < amount; ++i) {
@@ -61,6 +94,11 @@ void led_blink_error(int amount) {
 		#ifdef RP2040ZERO
 		ws2812_put_rgb(255, 0, 0);
 		#endif
+                #ifdef PICO_RGB
+                gpio_put(PICO_RED_PIN, 1);
+                gpio_put(PICO_GRN_PIN, 0);
+                gpio_put(PICO_BLU_PIN, 0);
+                #endif
 		sleep_ms(500);
 		#ifdef PICO
 		gpio_put(PICO_LED_PIN, false);
@@ -68,6 +106,11 @@ void led_blink_error(int amount) {
 		#ifdef RP2040ZERO
 		ws2812_put_rgb(0, 0, 0);
 		#endif
+                #ifdef PICO_RGB
+                gpio_put(PICO_RED_PIN, 0);
+                gpio_put(PICO_GRN_PIN, 0);
+                gpio_put(PICO_BLU_PIN, 0);
+                #endif
 		sleep_ms(500);
 	}
 }
@@ -86,6 +129,15 @@ void led_output_mc_change() {
 	sleep_ms(100);
 	ws2812_put_rgb(0, 0, 0);
 	#endif
+        #ifdef PICO_RGB
+        gpio_put(PICO_RED_PIN, 0);  // blue
+        gpio_put(PICO_GRN_PIN, 0);
+        gpio_put(PICO_BLU_PIN, 1);
+	sleep_ms(100);
+        gpio_put(PICO_RED_PIN, 0);
+        gpio_put(PICO_GRN_PIN, 0);
+        gpio_put(PICO_BLU_PIN, 0);
+        #endif
 }
 
 void led_output_end_mc_list() {
@@ -104,6 +156,15 @@ void led_output_end_mc_list() {
 	sleep_ms(500);
 	ws2812_put_rgb(0, 0, 0);
 	#endif
+        #ifdef PICO_RGB
+        gpio_put(PICO_RED_PIN, 1);      // purple
+        gpio_put(PICO_GRN_PIN, 0);
+        gpio_put(PICO_BLU_PIN, 1);
+        sleep_ms(500);
+        gpio_put(PICO_RED_PIN, 0);
+        gpio_put(PICO_GRN_PIN, 0);
+        gpio_put(PICO_BLU_PIN, 0);
+        #endif
 }
 
 void led_output_new_mc() {
@@ -122,4 +183,13 @@ void led_output_new_mc() {
 	sleep_ms(1000);
 	ws2812_put_rgb(0, 0, 0);
 	#endif
+        #ifdef PICO_RGB
+        gpio_put(PICO_RED_PIN, 0);      // teal
+        gpio_put(PICO_GRN_PIN, 1);
+        gpio_put(PICO_BLU_PIN, 1);
+        sleep_ms(1000);
+        gpio_put(PICO_RED_PIN, 0);
+        gpio_put(PICO_GRN_PIN, 0);
+        gpio_put(PICO_BLU_PIN, 0);
+        #endif
 }


### PR DESCRIPTION
I tried to mirror the LED colors of the Zero board. I based this off of 1.0.2, as 1.0.3 doesn't seem to work yet.

See #68 for information about the Aliexpress (BitfunX) board. It would be easy enough to make a test rig with a regular off-the-shelf Pico, and just hook up LEDs to GPIO 23 and 24.

I tested the firmware with my Aliexpress PicoMemcard and it seems to work fine, but more testing is welcome.