### PR TITLE
Added support for Bitfunx memory card and Game ID functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,9 @@ add_definitions(-DNO_PICO_LED)  # prevent SD SPI library from using LED
 add_subdirectory(no-OS-FatFS-SD-SPI-RPi-Pico/FatFs_SPI PicoMemcard)
 add_subdirectory(poc_examples)
 
+#optimization flag
+add_compile_options(-O2)
+
 # Example source
 target_sources(PicoMemcard PUBLIC
     ${CMAKE_SOURCE_DIR}/src/led.c

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Special thanks to everybody that supported it so far! You are all amazing.
 For people interested in understanding how PicoMemcard works I provide a more extensive explanation in [this post] (although now somewhat outdated).
 
 ## Thanks To
-* []
+* [Schermaiolo] - Writing the Game ID write function
 * [SantX27] - Debugging the 1.0.3 firmware to work on the Bitfunx Memory card
 * [wired-filipino-owl] - Documentation and implementation of the led functionality on the Bitfunx Memory card.
 * [psx-spx] and Martin "NO$PSX" Korth - PlayStation Specifications and documented Memory Card protocol and filesystem.
@@ -201,6 +201,7 @@ For people interested in understanding how PicoMemcard works I provide a more ex
 * [Scoppy] - Use your Raspberry Pi Pico as an oscilloscope, very cheap and accurate. Without this I would have not been able to debug many issues.
 * [PulseView] - Used to import, visualize and manipulate the data from Scoppy on a PC.
 
+[Schermaiolo]: https://github.com/schermaiolo
 [SantX27]: https://github.com/SantX27
 [wired-filipino-owl]: https://github.com/wired-filipino-owl
 [FreePSXBoot]: https://github.com/brad-lin/FreePSXBoot

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Additionally you can create a new empty memory card image (and automatically swi
 
 Additionally this method does not work on PS2 Memory Cards and Controllers are wired on a different bus.
 
+## Game ID
+On **PicoMemcard+** you can switch automatically to a virtual memory card based on the game you are playing, without any input, if you are using an Xstation, Unirom or a patched BIOS.
+
 ## Syncing Changes
 Generally speaking, new data written to PicoMemcard (e.g. when you save) is permanently stored only after a short period of time (due to hardware limitation). The on board LED indicates whether all changes have been stored or not, in particular:
 * On Rapsbery Pi Pico the LED will be on when all changes have been saved, off otherwise.
@@ -157,16 +160,20 @@ In particular, the RP2040-Zero has RGB LED that provides a more clear output. Th
 | Data synced | Led on | Green solid led |
 
 ### PicoMemcard+ Status
-| Status | Pico | RP2040-Zero
-| --- | --- | --- |
-| Failed to read SD card | Blinking led  | Red blinking led
-| Data not fully synced (do not turn off PSX)| Led off | Red led (or flashing red and green) |
-| Data synced | Led on | Green solid led |
-| Memory Card image changed | Three fast blinks | Single blue blink |
-| Memory Card image not changed (end of list) | Nine fast blinks | Single orange blink |
-| New Memory Card image created | Multiple very fast blinks | Single light blue blink |
+| Status | Pico | RP2040-Zero | Bitfunx Memory card
+| --- | --- | --- | --- |
+| Failed to read SD card | Blinking led  | Red blinking led | Red blinking led |
+| Data not fully synced (do not turn off PSX)| Led off | Yellow led | Yellow led |
+| Data synced | Led on | Green led | Green led |
+| Memory Card image changed | Three fast blinks | Single blue blink | Single blue blink |
+| Memory Card image not changed (end of list) | Nine fast blinks | Single orange blink | Single purple blink |
+| New Memory Card image created | Multiple very fast blinks | Single light blue blink | Single light blue blink |
 
 ## General Warnings
+This fork has not been tested with a PicoMemcard+ (because i don't have one) but with a Bitfunx Memory card. This version of the firmware may or may not work with your board.
+
+Due to Hardware limitations the Game ID functionality can't detect a disc swap in multidisc game, if you boot the second cd a new memory card will be created without transfering your progress.
+
 I would recommend to never plug PicoMemcard both into the PC (via USB) and the PSX at the same time! Otherwise the 5V provided by USB would end up on the 3.3V rail of the PSX. I'm not really sure if this could cause actual damage but I would avoid risking it.
 
 If you really need to have the Pico plugged into both the USB and PSX (e.g. for debugging purposes), disconnect the 3.3V line from the VBUS pin. In this way you can power on the Pico using a simple USB phone charger or by plugging it into your PC.
@@ -184,6 +191,9 @@ Special thanks to everybody that supported it so far! You are all amazing.
 For people interested in understanding how PicoMemcard works I provide a more extensive explanation in [this post] (although now somewhat outdated).
 
 ## Thanks To
+* []
+* [SantX27] - Debugging the 1.0.3 firmware to work on the Bitfunx Memory card
+* [wired-filipino-owl] - Documentation and implementation of the led functionality on the Bitfunx Memory card.
 * [psx-spx] and Martin "NO$PSX" Korth - PlayStation Specifications and documented Memory Card protocol and filesystem.
 * [Andrew J. McCubbin] - Additional information about Memory Card and Controller communication with PSX.
 * [littlefs] - Filesystem designed to work on NOR flash used by many microcontrollers, including the Raspberry Pi Pico.
@@ -191,6 +201,8 @@ For people interested in understanding how PicoMemcard works I provide a more ex
 * [Scoppy] - Use your Raspberry Pi Pico as an oscilloscope, very cheap and accurate. Without this I would have not been able to debug many issues.
 * [PulseView] - Used to import, visualize and manipulate the data from Scoppy on a PC.
 
+[SantX27]: https://github.com/SantX27
+[wired-filipino-owl]: https://github.com/wired-filipino-owl
 [FreePSXBoot]: https://github.com/brad-lin/FreePSXBoot
 [psx-spx]: https://psx-spx.consoledev.net/pinouts/#controller-ports-and-memory-card-ports
 [Andrew J. McCubbin]: http://www.emudocs.org/PlayStation/psxcont/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ PicoMemcard allows you to build your own supercharged PSX Memory Card that can b
 * Allows to play burned CDs (thanks to [FreePSXBoot])
 * Cheaper than an original memory card
 * Can store hudreds of memory card images
+* Switching memory cards using MemcardPro commands with L2/R2
 
 ## Bill of materials
 * **Raspberry Pi Pico** (around $5)
@@ -111,7 +112,9 @@ Inside `docs/images` you can find two memory card images. One has a couple of sa
 ## Switching/Creating Images
 On **PicoMemcard+** you can switch the active memory card image with the following inputs:
 * `START + SELECT + DPAD UP` will switch to the next image (e.g from `1.MCR` to `2.MCR`).
+* `START + SELECT + DPAD RIGHT` will switch to the next image by 5 (e.g from `1.MCR` to `6.MCR`).
 * `START + SELECT + DPAD DOWN` will switch to the previous image (e.g from `1.MCR` to `0.MCR`).
+* `START + SELECT + DPAD LEFT` will switch to the previous image by 5 (e.g from `6.MCR` to `1.MCR`).
 
 Additionally you can create a new empty memory card image (and automatically switch to it) by pressing  `START + SELECT + TRIANGLE`.
 
@@ -193,6 +196,7 @@ For people interested in understanding how PicoMemcard works I provide a more ex
 ## Thanks To
 * [Schermaiolo] - Writing the Game ID write function
 * [SantX27] - Debugging the 1.0.3 firmware to work on the Bitfunx Memory card
+* [whitezombie2000] - Extensive debugging and report of all bugs related to Picomemcard, without him the releases would be way more buggy.
 * [wired-filipino-owl] - Documentation and implementation of the led functionality on the Bitfunx Memory card.
 * [psx-spx] and Martin "NO$PSX" Korth - PlayStation Specifications and documented Memory Card protocol and filesystem.
 * [Andrew J. McCubbin] - Additional information about Memory Card and Controller communication with PSX.
@@ -203,6 +207,7 @@ For people interested in understanding how PicoMemcard works I provide a more ex
 
 [Schermaiolo]: https://github.com/schermaiolo
 [SantX27]: https://github.com/SantX27
+[whitezombie2000]: https://github.com/whitezombie2000
 [wired-filipino-owl]: https://github.com/wired-filipino-owl
 [FreePSXBoot]: https://github.com/brad-lin/FreePSXBoot
 [psx-spx]: https://psx-spx.consoledev.net/pinouts/#controller-ports-and-memory-card-ports

--- a/inc/config.h
+++ b/inc/config.h
@@ -7,7 +7,7 @@
 #define IDLE_AUTOSYNC_TIMEOUT 5 * 1000		// time (in ms) the memory card must be inactive before automatic sync from RAM to LFS
 #define MAX_MC_FILENAME_LEN	32				// max length of memory card file name (including extension)
 #define MAX_MC_IMAGES	255					// maximum number of different mc images
-#define MC_RECONNECT_TIME	1000				// time (in ms) the memory card stays disconnected when simulating reconnection
+#define MC_RECONNECT_TIME	250				// time (in ms) the memory card stays disconnected when simulating reconnection
 
 /* Board targeted by build */
 //#define PICO

--- a/inc/config.h
+++ b/inc/config.h
@@ -10,8 +10,10 @@
 #define MC_RECONNECT_TIME	1000				// time (in ms) the memory card stays disconnected when simulating reconnection
 
 /* Board targeted by build */
-#define PICO
+//#define PICO
 //#define RP2040ZERO
+#define BITFUNX
+#define GAMEID
 
 /* Invert red and green. Uncomment this if the LED colours for your RP2040 Zero are incorrect. */
 #define INVERT_RED_GREEN
@@ -33,6 +35,14 @@
 	#define PIN_ACK 13
 #endif
 
+#ifdef BITFUNX
+	//#define PIN_DAT 5
+	//#define PIN_CMD PIN_DAT + 1		// must be immediately after PIN_DAT
+	//#define PIN_SEL PIN_CMD + 1		// must be immediately after PIN_CMD
+	//#define PIN_CLK PIN_SEL + 1		// must be immediately after PIN_SEL
+	//#define PIN_ACK 9
+#endif
+
 /* SD Card Configuration */
 #define BLOCK_SIZE	512				// SD card communicate using only 512 block size for consistency
 #define BAUD_RATE	5000 * 1000
@@ -48,6 +58,13 @@
 	#define PIN_MOSI	3
 	#define PIN_SCK		2
 	#define PIN_SS		1
+#endif
+
+#ifdef BITFUNX
+	#define PIN_MISO	16
+	#define PIN_MOSI	19
+	#define PIN_SCK		18
+	#define PIN_SS		17
 #endif
 
 #endif

--- a/inc/memcard_manager.h
+++ b/inc/memcard_manager.h
@@ -20,6 +20,7 @@ bool memcard_manager_exist(uint8_t* filename);
 uint32_t memcard_manager_count();
 uint32_t memcard_manager_get(uint32_t index, uint8_t* out_filename);
 #define memcard_manager_get_initial(out_filename) memcard_manager_get(memcard_manager_get_prev_loaded_memcard_index(), (out_filename))
+uint32_t update_prev_loaded_memcard_index(uint32_t index);
 uint32_t memcard_manager_get_prev_loaded_memcard_index();
 uint32_t memcard_manager_get_next(uint8_t* filename, uint8_t* out_nextfile);
 uint32_t memcard_manager_get_prev(uint8_t* filename, uint8_t* out_prevfile);

--- a/inc/memcard_manager.h
+++ b/inc/memcard_manager.h
@@ -23,8 +23,8 @@ uint32_t memcard_manager_get(uint32_t index, uint8_t* out_filename);
 #define memcard_manager_get_initial(out_filename) memcard_manager_get(memcard_manager_get_prev_loaded_memcard_index(), (out_filename))
 uint32_t update_prev_loaded_memcard_index(uint32_t index);
 uint32_t memcard_manager_get_prev_loaded_memcard_index();
-uint32_t memcard_manager_get_next(uint8_t* filename, uint8_t* out_nextfile);
-uint32_t memcard_manager_get_prev(uint8_t* filename, uint8_t* out_prevfile);
+uint32_t memcard_manager_get_next(uint8_t* filename, uint8_t* out_nextfile, bool skip);
+uint32_t memcard_manager_get_prev(uint8_t* filename, uint8_t* out_prevfile, bool skip);
 uint32_t memcard_manager_create(uint8_t* out_filename);
 uint32_t create_index(uint8_t *vec, uint8_t size, uint8_t *out_filename);
 #endif

--- a/inc/memcard_manager.h
+++ b/inc/memcard_manager.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
+
 
 /* Error codes */
 #define MM_OK					0
@@ -23,4 +25,6 @@ uint32_t memcard_manager_get_next(uint8_t* filename, uint8_t* out_nextfile);
 uint32_t memcard_manager_get_prev(uint8_t* filename, uint8_t* out_prevfile);
 uint32_t memcard_manager_create(uint8_t* out_filename);
 
+
+uint32_t create_index(uint8_t *vec, uint8_t size, uint8_t *out_filename);
 #endif

--- a/inc/memcard_manager.h
+++ b/inc/memcard_manager.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <ctype.h>
 
 
 /* Error codes */
@@ -25,7 +26,5 @@ uint32_t memcard_manager_get_prev_loaded_memcard_index();
 uint32_t memcard_manager_get_next(uint8_t* filename, uint8_t* out_nextfile);
 uint32_t memcard_manager_get_prev(uint8_t* filename, uint8_t* out_prevfile);
 uint32_t memcard_manager_create(uint8_t* out_filename);
-
-
 uint32_t create_index(uint8_t *vec, uint8_t size, uint8_t *out_filename);
 #endif

--- a/src/led.c
+++ b/src/led.c
@@ -14,6 +14,12 @@
 #define PICO_LED_PIN 25
 #endif
 
+#ifdef BITFUNX
+#define PICO_RED_PIN 25
+#define PICO_GRN_PIN 24
+#define PICO_BLU_PIN 23
+#endif
+
 static uint smWs2813;
 static uint offsetWs2813;
 static int32_t picoW = -1;
@@ -34,19 +40,27 @@ void ws2812_put_rgb(uint8_t red, uint8_t green, uint8_t blue) {
 #endif
 
 void led_init() {
-  #ifdef PICO
-  if (is_pico_w()) {
-    if (cyw43_arch_init()) {
-      picoW = 0;
-    }
-  }
-  init_led(PICO_LED_PIN);
-  #endif
-	#ifdef RP2040ZERO
-	offsetWs2813 = pio_add_program(pio1, &ws2812_program);
-	smWs2813 = pio_claim_unused_sm(pio1, true);
-	ws2812_program_init(pio1, smWs2813, offsetWs2813, 16, 800000, true);
+   	#ifdef PICO
+   	if (is_pico_w()) {
+     	if (cyw43_arch_init()) {
+       	picoW = 0;
+     	}
+   	}
+   	init_led(PICO_LED_PIN);
 	#endif
+	#ifdef RP2040ZERO
+ 	offsetWs2813 = pio_add_program(pio1, &ws2812_program);
+ 	smWs2813 = pio_claim_unused_sm(pio1, true);
+ 	ws2812_program_init(pio1, smWs2813, offsetWs2813, 16, 800000, true);
+ 	#endif
+	#ifdef BITFUNX
+        gpio_init(PICO_RED_PIN);
+        gpio_init(PICO_GRN_PIN);
+        gpio_init(PICO_BLU_PIN);
+        gpio_set_dir(PICO_RED_PIN, GPIO_OUT); 
+        gpio_set_dir(PICO_GRN_PIN, GPIO_OUT); 
+        gpio_set_dir(PICO_BLU_PIN, GPIO_OUT); 
+    #endif
 }
 
 void led_output_sync_status(bool out_of_sync) {
@@ -61,6 +75,20 @@ void led_output_sync_status(bool out_of_sync) {
 		ws2812_put_rgb(0, 255, 0);
 	}
 	#endif
+	#ifdef BITFUNX
+    if(out_of_sync) {
+            //yellow
+            gpio_put(PICO_RED_PIN, 1);
+            gpio_put(PICO_GRN_PIN, 1);
+            gpio_put(PICO_BLU_PIN, 0);
+    }
+    else {
+            //green
+            gpio_put(PICO_RED_PIN, 0);
+            gpio_put(PICO_GRN_PIN, 1);
+            gpio_put(PICO_BLU_PIN, 0);
+    }
+    #endif
 }
 
 void led_blink_error(int amount) {
@@ -71,6 +99,11 @@ void led_blink_error(int amount) {
 	#ifdef RP2040ZERO
 	ws2812_put_rgb(0, 0, 0);
 	#endif
+	#ifdef BITFUNX
+    gpio_put(PICO_RED_PIN, 0);
+    gpio_put(PICO_GRN_PIN, 0);
+    gpio_put(PICO_BLU_PIN, 0);
+    #endif
 	sleep_ms(500);
 	/* start blinking */
 	for(int i = 0; i < amount; ++i) {
@@ -80,13 +113,23 @@ void led_blink_error(int amount) {
 		#ifdef RP2040ZERO
 		ws2812_put_rgb(255, 0, 0);
 		#endif
+		#ifdef BITFUNX
+        gpio_put(PICO_RED_PIN, 1);
+        gpio_put(PICO_GRN_PIN, 0);
+        gpio_put(PICO_BLU_PIN, 0);
+        #endif
 		sleep_ms(500);
 		#ifdef PICO
 		set_led(PICO_LED_PIN, false);
 		#endif
 		#ifdef RP2040ZERO
-		ws2812_put_rgb(0, 0, 0);
+	 	ws2812_put_rgb(0, 0, 0);
 		#endif
+		#ifdef BITFUNX
+        gpio_put(PICO_RED_PIN, 0);
+        gpio_put(PICO_GRN_PIN, 0);
+        gpio_put(PICO_BLU_PIN, 0);
+        #endif
 		sleep_ms(500);
 	}
 }
@@ -105,6 +148,15 @@ void led_output_mc_change() {
 	sleep_ms(100);
 	ws2812_put_rgb(0, 0, 0);
 	#endif
+	#ifdef BITFUNX
+    gpio_put(PICO_RED_PIN, 0);  // blue
+    gpio_put(PICO_GRN_PIN, 0);
+    gpio_put(PICO_BLU_PIN, 1);
+	sleep_ms(100);
+    gpio_put(PICO_RED_PIN, 0);
+    gpio_put(PICO_GRN_PIN, 0);
+    gpio_put(PICO_BLU_PIN, 0);
+    #endif
 }
 
 void led_output_end_mc_list() {
@@ -123,6 +175,15 @@ void led_output_end_mc_list() {
 	sleep_ms(500);
 	ws2812_put_rgb(0, 0, 0);
 	#endif
+	#ifdef BITFUNX
+    gpio_put(PICO_RED_PIN, 1);      // purple
+    gpio_put(PICO_GRN_PIN, 0);
+    gpio_put(PICO_BLU_PIN, 1);
+    sleep_ms(500);
+    gpio_put(PICO_RED_PIN, 0);
+    gpio_put(PICO_GRN_PIN, 0);
+    gpio_put(PICO_BLU_PIN, 0);
+    #endif
 }
 
 void led_output_new_mc() {
@@ -141,11 +202,21 @@ void led_output_new_mc() {
 	sleep_ms(1000);
     ws2812_put_rgb(0, 0, 0);
 	#endif
+	#ifdef BITFUNX
+    gpio_put(PICO_RED_PIN, 0);      // teal
+    gpio_put(PICO_GRN_PIN, 1);
+    gpio_put(PICO_BLU_PIN, 1);
+    sleep_ms(1000);
+    gpio_put(PICO_RED_PIN, 0);
+    gpio_put(PICO_GRN_PIN, 0);
+    gpio_put(PICO_BLU_PIN, 0);
+    #endif
 }
 
 // Attempt to check if device is a Raspberry Pi Pico W
 // Based on https://forums.raspberrypi.com/viewtopic.php?t=336884
 int32_t is_pico_w() {
+	#ifdef PICO
   if (picoW == -1) {
     // When the VSYS_ADC is read on a Pico it will always be > 1V
     // On a Pico-W it will be < 1V when GPIO25 is low
@@ -173,8 +244,14 @@ int32_t is_pico_w() {
     }
   }
   return picoW;
+  #endif
+  
+  #ifdef BITFUNX
+  return 0;
+  #endif
 }
 
+#ifdef PICO
 void init_led(uint32_t pin) {
   if (!is_pico_w() || (pin != 25)) {
     gpio_init(pin);
@@ -182,7 +259,7 @@ void init_led(uint32_t pin) {
   }
 }
 
-#ifdef PICO
+
 void set_led(uint32_t pin, uint32_t level) {
   if ((pin == 25) && is_pico_w()) {
     cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, level);

--- a/src/main.c
+++ b/src/main.c
@@ -35,7 +35,7 @@ int main(void) {
 		if(to_ms_since_boot(get_absolute_time()) > TUD_MOUNT_TIMEOUT && !tud_mount_status)
 			break;
 	}
-	
+
 	/* Pico powered by PSX, initialize memory card simulation */
 	simulate_memory_card();	
 

--- a/src/memcard_simulator.c
+++ b/src/memcard_simulator.c
@@ -350,9 +350,11 @@ _Noreturn int simulate_memory_card() {
 		while(true)
 			led_blink_error(1);
 	}
+    printf("sd card mounted\n");
 
     uint32_t status = memory_card_init(&mc);
 	if(status != MC_OK) {
+        printf("could not init memcard\n");
 		while(true) {
 			led_blink_error(status);
 			sleep_ms(2000);
@@ -362,14 +364,17 @@ _Noreturn int simulate_memory_card() {
 	if(status != MM_OK) {
 		status = memcard_manager_get(0, mc_file_name);	// revert to first mem card if failing to load previously loaded card
 		if(status != MM_OK) {
+            printf("could not load memcard\n");
 			while(true) {
 				led_blink_error(status);
 				sleep_ms(1000);
 			}
 		}
 	}
+    printf("mcfilename: %s\n", mc_file_name);
 	status = memory_card_import(&mc, mc_file_name);
 	if(status != MC_OK) {
+        printf("could not import memcard\n");
 		while(true) {
 			led_blink_error(status);
 			sleep_ms(2000);
@@ -430,6 +435,8 @@ _Noreturn int simulate_memory_card() {
                     /* switch mc */
                     strcpy(mc_file_name, new_file_name);
                     status = memory_card_import(&mc, mc_file_name);
+                    update_prev_loaded_memcard_index(atoi(mc_file_name));
+                    printf("mc is: %s\n", mc_file_name);
                     if(status != MC_OK)
                         led_blink_error(status);
                     simulate_mc_reconnect();
@@ -482,7 +489,6 @@ _Noreturn int simulate_memory_card() {
             }else
                 led_blink_error(status);
             simulate_mc_reconnect();
-            //update_prev_loaded_memcard_index(atoi(new_name));
             indexfile = false;
             mutex_exit(&write_transaction);
         }


### PR DESCRIPTION
As stated in the title this will add the GameID functionality to automatically create and/or switch the memory card based on the game the xstation/uniboot loads. This can be enable/disable via config.h. It also adds support for the bitfunx memory card